### PR TITLE
Padronização dos Controllers

### DIFF
--- a/app/api/v1/migrations/route.js
+++ b/app/api/v1/migrations/route.js
@@ -2,6 +2,7 @@ import migrationRunner from "node-pg-migrate";
 import { resolve } from "path";
 import database from "infra/database.js";
 import { NextResponse } from "next/server";
+import { InternalServerError, MethodNotAllowedError } from "@/infra/errors";
 
 async function runMigrations(dryRun) {
   let dbClient;
@@ -12,6 +13,7 @@ async function runMigrations(dryRun) {
       dir: resolve("infra", "migrations"),
       dryRun,
       direction: "up",
+      verbose: process.env.NODE_ENV === "development",
       migrationsTable: "pgmigrations",
     };
 
@@ -28,11 +30,16 @@ export async function GET() {
     const pendingMigrations = await runMigrations(true);
     return NextResponse.json(pendingMigrations, { status: 200 });
   } catch (error) {
-    console.error(error);
-    return NextResponse.json(
-      { error: "Internal Server Error" },
-      { status: 500 },
+    const publicErrorObject = new InternalServerError({
+      cause: error,
+    });
+    console.error(
+      "\n<===> Controller Error <===> Error fetching status:",
+      publicErrorObject,
     );
+    return NextResponse.json(publicErrorObject, {
+      status: publicErrorObject.statusCode,
+    });
   }
 }
 
@@ -42,10 +49,29 @@ export async function POST() {
     const status = migratedMigrations.length > 0 ? 201 : 200;
     return NextResponse.json(migratedMigrations, { status });
   } catch (error) {
-    console.error(error);
-    return NextResponse.json(
-      { error: "Internal Server Error" },
-      { status: 500 },
+    const publicErrorObject = new InternalServerError({
+      cause: error,
+    });
+    console.error(
+      "\n<===> Controller Error <===> Error running migrations:",
+      publicErrorObject,
     );
+    return NextResponse.json(publicErrorObject, {
+      status: publicErrorObject.statusCode,
+    });
   }
+}
+
+export async function PUT() {
+  return custom405();
+}
+export async function DELETE() {
+  return custom405();
+}
+
+function custom405() {
+  const methodNotAllowedError = new MethodNotAllowedError();
+  return new NextResponse(JSON.stringify(methodNotAllowedError), {
+    status: methodNotAllowedError.statusCode,
+  });
 }

--- a/app/api/v1/status/route.js
+++ b/app/api/v1/status/route.js
@@ -1,5 +1,5 @@
 import database from "@/infra/database.js";
-import { InternalServerError } from "@/infra/errors";
+import { InternalServerError, MethodNotAllowedError } from "@/infra/errors";
 import { NextResponse } from "next/server";
 
 export async function GET() {
@@ -34,12 +34,35 @@ export async function GET() {
       },
     });
   } catch (error) {
+    console.log(error);
+
     const publicErrorObject = new InternalServerError({
       cause: error,
+      code: error?.statusCode,
     });
-    console.error("Error fetching status:", publicErrorObject);
+    console.error(
+      "\n<===> Controller Error <===> Error fetching status:",
+      publicErrorObject,
+    );
     return NextResponse.json(publicErrorObject, {
       status: publicErrorObject.statusCode,
     });
   }
+}
+
+export async function POST() {
+  return custom405();
+}
+export async function PUT() {
+  return custom405();
+}
+export async function DELETE() {
+  return custom405();
+}
+
+function custom405() {
+  const methodNotAllowedError = new MethodNotAllowedError();
+  return new NextResponse(JSON.stringify(methodNotAllowedError), {
+    status: methodNotAllowedError.statusCode,
+  });
 }

--- a/infra/database.js
+++ b/infra/database.js
@@ -1,4 +1,5 @@
 import { Client } from "pg";
+import { ServiceUnavailableError } from "./errors";
 
 async function query(queryObj) {
   let client;
@@ -7,8 +8,15 @@ async function query(queryObj) {
     client = await getNewClient();
     return await client.query(queryObj);
   } catch (error) {
-    console.error(error);
-    throw error;
+    const serviceError = new ServiceUnavailableError({
+      message: "Erro ao executar a consulta no banco de dados.",
+      cause: error,
+    });
+    console.error(
+      "\n<===> Database Error <===> An error occurred while executing a database query:",
+      serviceError,
+    );
+    throw serviceError;
   } finally {
     await client?.end();
   }

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -1,5 +1,5 @@
 class InternalServerError extends Error {
-  constructor({ cause }) {
+  constructor({ cause, code }) {
     super(
       "Um erro interno não esperado aconteceu. Tente novamente mais tarde.",
       {
@@ -7,7 +7,7 @@ class InternalServerError extends Error {
       },
     );
     this.name = "InternalServerError";
-    this.statusCode = 500;
+    this.statusCode = code || 500;
     this.action = "Se o erro persistir, entre em contato com o suporte.";
   }
 
@@ -21,4 +21,48 @@ class InternalServerError extends Error {
   }
 }
 
-export { InternalServerError };
+class ServiceUnavailableError extends Error {
+  constructor({ cause, message }) {
+    super(
+      message ||
+        "O serviço está temporariamente indisponível. Tente novamente mais tarde.",
+      {
+        cause,
+      },
+    );
+    this.name = "ServiceUnavailableError";
+    this.statusCode = 503;
+    this.action =
+      "Serviço indisponível no momento. Se o problema persistir, entre em contato com o suporte.";
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      status_code: this.statusCode,
+      action: this.action,
+    };
+  }
+}
+
+class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido para este endpoint.");
+    this.name = "MethodNotAllowedError";
+    this.statusCode = 405;
+    this.action =
+      "Verifique se o método HTTP utilizado é permitido para este endpoint e corrija a requisição.";
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      status_code: this.statusCode,
+      action: this.action,
+    };
+  }
+}
+
+export { InternalServerError, ServiceUnavailableError, MethodNotAllowedError };

--- a/tests/integration/api/v1/migrations/delete.test.js
+++ b/tests/integration/api/v1/migrations/delete.test.js
@@ -1,0 +1,31 @@
+import webserver from "@/infra/webserver";
+import { waitForAllServices } from "@/tests/orchestrator";
+
+beforeAll(async () => {
+  await waitForAllServices();
+});
+
+describe("DELETE /api/v1/migrations", () => {
+  describe("Anonymous user", () => {
+    test("Attempting to delete from migrations endpoint, should return 405", async () => {
+      const responseBody = await fetch(
+        `${webserver.getOrigin}/api/v1/migrations`,
+        {
+          method: "DELETE",
+        },
+      );
+
+      const responseJson = await responseBody.json();
+
+      expect(responseBody.status).toBe(405);
+
+      expect(responseJson).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        status_code: 405,
+        action:
+          "Verifique se o método HTTP utilizado é permitido para este endpoint e corrija a requisição.",
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/migrations/put.test.js
+++ b/tests/integration/api/v1/migrations/put.test.js
@@ -1,0 +1,31 @@
+import webserver from "@/infra/webserver";
+import { waitForAllServices } from "@/tests/orchestrator";
+
+beforeAll(async () => {
+  await waitForAllServices();
+});
+
+describe("PUT /api/v1/migrations", () => {
+  describe("Anonymous user", () => {
+    test("Attempting to put on migrations endpoint, should return 405", async () => {
+      const responseBody = await fetch(
+        `${webserver.getOrigin}/api/v1/migrations`,
+        {
+          method: "PUT",
+        },
+      );
+
+      const responseJson = await responseBody.json();
+
+      expect(responseBody.status).toBe(405);
+
+      expect(responseJson).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        status_code: 405,
+        action:
+          "Verifique se o método HTTP utilizado é permitido para este endpoint e corrija a requisição.",
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/status/delete.test.js
+++ b/tests/integration/api/v1/status/delete.test.js
@@ -1,0 +1,28 @@
+import webserver from "@/infra/webserver";
+import { waitForAllServices } from "@/tests/orchestrator";
+
+beforeAll(async () => {
+  await waitForAllServices();
+});
+
+describe("DELETE /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Attempting to delete from status endpoint, should return 405", async () => {
+      const responseBody = await fetch(`${webserver.getOrigin}/api/v1/status`, {
+        method: "DELETE",
+      });
+
+      const responseJson = await responseBody.json();
+
+      expect(responseBody.status).toBe(405);
+
+      expect(responseJson).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        status_code: 405,
+        action:
+          "Verifique se o método HTTP utilizado é permitido para este endpoint e corrija a requisição.",
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/status/get.test.js
+++ b/tests/integration/api/v1/status/get.test.js
@@ -1,8 +1,16 @@
 import webserver from "@/infra/webserver";
-import { waitForAllServices } from "@/tests/orchestrator";
+import {
+  startDatabase,
+  stopDatabase,
+  waitForAllServices,
+} from "@/tests/orchestrator";
 
 beforeAll(async () => {
   await waitForAllServices();
+});
+
+afterAll(() => {
+  startDatabase();
 });
 
 describe("GET /api/v1/status", () => {
@@ -19,6 +27,25 @@ describe("GET /api/v1/status", () => {
       expect(responseBody.dependencies.database.version).toEqual("18.0");
       expect(responseBody.dependencies.database.max_connections).toEqual(100);
       expect(responseBody.dependencies.database.opened_connections).toEqual(1);
+    });
+
+    test("Retrieving status with database error, should return 503", async () => {
+      stopDatabase();
+      const response = await fetch(`${webserver.getOrigin}/api/v1/status`);
+
+      const responseJson = await response.json();
+
+      expect(response.status).toBe(503);
+
+      expect(responseJson).toEqual({
+        name: "InternalServerError",
+        message:
+          "Um erro interno não esperado aconteceu. Tente novamente mais tarde.",
+        status_code: 503,
+        action: "Se o erro persistir, entre em contato com o suporte.",
+      });
+
+      startDatabase();
     });
   });
 });

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,28 @@
+import webserver from "@/infra/webserver";
+import { waitForAllServices } from "@/tests/orchestrator";
+
+beforeAll(async () => {
+  await waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Attempting to post to status endpoint, should return 405", async () => {
+      const responseBody = await fetch(`${webserver.getOrigin}/api/v1/status`, {
+        method: "POST",
+      });
+
+      const responseJson = await responseBody.json();
+
+      expect(responseBody.status).toBe(405);
+
+      expect(responseJson).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        status_code: 405,
+        action:
+          "Verifique se o método HTTP utilizado é permitido para este endpoint e corrija a requisição.",
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/status/put.test.js
+++ b/tests/integration/api/v1/status/put.test.js
@@ -1,0 +1,28 @@
+import webserver from "@/infra/webserver";
+import { waitForAllServices } from "@/tests/orchestrator";
+
+beforeAll(async () => {
+  await waitForAllServices();
+});
+
+describe("PUT /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Attempting to put on status endpoint, should return 405", async () => {
+      const responseBody = await fetch(`${webserver.getOrigin}/api/v1/status`, {
+        method: "PUT",
+      });
+
+      const responseJson = await responseBody.json();
+
+      expect(responseBody.status).toBe(405);
+
+      expect(responseJson).toEqual({
+        name: "MethodNotAllowedError",
+        message: "Método não permitido para este endpoint.",
+        status_code: 405,
+        action:
+          "Verifique se o método HTTP utilizado é permitido para este endpoint e corrija a requisição.",
+      });
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,6 +1,7 @@
 import retry from "async-retry";
 import webserver from "@/infra/webserver";
 import database from "@/infra/database";
+import { execSync } from "child_process";
 
 export async function waitForAllServices() {
   await waitForWebService();
@@ -21,6 +22,14 @@ export async function waitForAllServices() {
   }
 }
 
+export function stopDatabase() {
+  execSync("npm run services:stop");
+}
+
+export function startDatabase() {
+  execSync("npm run services:up");
+}
+
 export async function clearDatabase() {
   await database.query("drop schema public cascade; create schema public;");
 }
@@ -28,6 +37,8 @@ export async function clearDatabase() {
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
+  stopDatabase,
+  startDatabase,
 };
 
 export default orchestrator;


### PR DESCRIPTION
Padroniza os Controllers dos endpoints `/migrations` e `/status`.
Adiciona 2 novos erros customizados: `MethodNotAllowedError` e `ServiceError`.
Faz o `InternalServerError` aceitar injeção do `statusCode`.